### PR TITLE
[WM] add user-id upcoming election search

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -4,4 +4,5 @@
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
             :queues {"election-http-api.ok" {:exclusive false :durable true :auto-delete false}
-                     "election-works.election.search" {:exclusive false :durable true :auto-delete false}}}}
+                     "election-works.election.search" {:exclusive false :durable true :auto-delete false}
+                     "electorate-works.electorate.search-create" {:exclusive false :durable true :auto-delete false}}}}

--- a/src/election_http_api/channels.clj
+++ b/src/election_http_api/channels.clj
@@ -7,6 +7,10 @@
 
 (defonce election-upcoming-search (async/chan 1000))
 
+(defonce electorate-search-create (async/chan 1000))
+
 (defn close-all! []
-  (doseq [c [ok-requests ok-responses]]
+  (doseq [c [ok-requests ok-responses
+             election-upcoming-search
+             electorate-search-create]]
     (async/close! c)))

--- a/src/election_http_api/queue.clj
+++ b/src/election_http_api/queue.clj
@@ -25,7 +25,15 @@
                               "election-works.election.search"
                               (config [:rabbitmq :queues "election-works.election.search"])
                               5000
-                              channels/election-upcoming-search)]
+                              channels/election-upcoming-search)
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "electorate-works.electorate.search-create"
+                              (config [:rabbitmq :queues
+                                       "electorate-works.electorate.search-create"])
+                              5000
+                              channels/electorate-search-create)]
           outgoing-events []]
 
       (wire-up/start-responder! channels/ok-requests

--- a/src/election_http_api/service.clj
+++ b/src/election_http_api/service.clj
@@ -29,18 +29,26 @@
                                                        "application/json"
                                                        "text/plain"])]
      ["/ping" {:get [:ping ping]}]
-     ["/upcoming" {:get [:search-upcoming
-                         (bifrost/interceptor
-                          channels/election-upcoming-search)]}
+     ["/upcoming" ^:constraints {:district-divisions #".+"}
+      {:get [:search-upcoming-by-district-divisions
+             (bifrost/interceptor
+              channels/election-upcoming-search)]}
       ^:interceptors [(bifrost.i/update-in-request
                        [:query-params :district-divisions]
-                       #(if %
-                          (-> %
-                              (str/split #",")
-                              vec)
-                          []))
+                       #(-> %
+                            (str/split #",")
+                            vec))
                       (bifrost.i/update-in-response
-                       [:body :elections] [:body] identity)]]]]])
+                       [:body :elections] [:body] identity)]]
+     ["/upcoming" ^:constraints {:user-id #".+"}
+      {:get [:search-upcoming-by-user-id
+             (bifrost/interceptor
+              channels/electorate-search-create)]}
+      ^:interceptors [(bifrost.i/update-in-request
+                       [:query-params :user-id]
+                       #(when % (java.util.UUID/fromString %)))
+                      (bifrost.i/update-in-response
+                       [:body :electorates] [:body] identity)]]]]])
 
 (defn service []
   {::env :prod

--- a/test/election_http_api/service_test.clj
+++ b/test/election_http_api/service_test.clj
@@ -35,7 +35,9 @@
    :date date
    :district-divisions #{district-ocd-id}})
 
-(def denver-ocd-id "ocd-division/country:us/state:co/county:denver")
+(def co-ocd-id "ocd-division/country:us/state:co")
+
+(def denver-ocd-id (str co-ocd-id "/county:denver"))
 
 (def denver-election (test-election denver-ocd-id
                                     (-> (t/today)
@@ -49,23 +51,57 @@
                                            :elections #{denver-election}})
     (async/put! response-ch {:status :ok, :elections #{}})))
 
+(def test-user-1
+  {:id #uuid "a9acf0fb-5e74-4afb-822a-0078aec27e37"})
+
+(defn test-electorate-works-upcoming-response
+  [[response-ch {:keys [user-id] :as request}]]
+  (condp = user-id
+    (:id test-user-1)
+    (async/put! response-ch {:status :ok
+                             :electorates
+                             #{{:election denver-election
+                                :user test-user-1
+                                :election-authority {}
+                                :voter-registration-authority {}}}})
+    (async/put! response-ch {:status :ok
+                             :electorates #{}})))
+
 (deftest upcoming-test
-  (testing "/upcoming responds with elections when found"
+  (testing "/upcoming?district-divisions=... responds with elections when found"
     (async/take! channels/election-upcoming-search
                  test-election-works-upcoming-response)
-    (let [co-ocd-id     "ocd-division/country:us/state:co"
-          response (http/get
+    (let [response (http/get
                     (str root-url "/upcoming")
                     {:query-params
                      {:district-divisions
                       (str/join "," #{co-ocd-id denver-ocd-id})}})]
       (is (= 200 (:status response)))
       (is (= #{denver-election}
-             (edn/read-string (:body response)))))
-    (testing "/upcoming with no elections returns empty success result"
-      (async/take! channels/election-upcoming-search
-                   test-election-works-upcoming-response)
-      (let [response (http/get
-                      (str root-url "/upcoming"))]
-        (is (= 200 (:status response)))
-        (is (empty? (edn/read-string (:body response))))))))
+             (edn/read-string (:body response))))))
+  (testing "/upcoming?district-divisions=... with no elections returns empty success result"
+    (async/take! channels/election-upcoming-search
+                 test-election-works-upcoming-response)
+    (let [response (http/get
+                    (str root-url "/upcoming")
+                    {:query-params
+                     {:district-divisions co-ocd-id}})]
+      (is (= 200 (:status response)))
+      (is (empty? (edn/read-string (:body response))))))
+  (testing "/upcoming?user-id=... responds with elections when found"
+    (async/take! channels/electorate-search-create
+                 test-electorate-works-upcoming-response)
+    (let [response (http/get
+                    (str root-url "/upcoming")
+                    {:query-params
+                     {:user-id (:id test-user-1)}})]
+      (is (= 200 (:status response)))
+      (is (= #{{:election denver-election
+                :user test-user-1
+                :election-authority {}
+                :voter-registration-authority {}}}
+             (edn/read-string (:body response))))))
+  (testing "/upcoming with no query params returns 404"
+    (let [response (http/get (str root-url "/upcoming")
+                             {:throw-exceptions false})]
+      (is (= 404 (:status response))))))


### PR DESCRIPTION
`/upcoming?user-id=[uuid]`

This allows us to already have the election authority address in the upcoming election search response (when there is one). This is exactly the kind of thing electorate-works was designed to help with.

Assigning to @ericnormand because he did the electorate-works side of this.