### PR TITLE
Use new pedestal-toolbox cors matcher.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ app:
     - rabbitmq
     - wildfly
   environment:
-    ALLOWED_ORIGINS: :all
+    ALLOWED_ORIGINS: '[".*"]'
 wildfly:
   image: quay.io/democracyworks/wildfly:9.0.2.Final-debug
   links:

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
 
                  [io.pedestal/pedestal.service "0.4.1"]
                  [io.pedestal/pedestal.service-tools "0.4.1"]
-                 [democracyworks/pedestal-toolbox "0.6.2"]
+                 [democracyworks/pedestal-toolbox "0.7.0"]
                  [org.immutant/web "2.1.1"]
                  [io.pedestal/pedestal.immutant "0.4.1"]
                  [org.immutant/core "2.1.1"]

--- a/src/election_http_api/service.clj
+++ b/src/election_http_api/service.clj
@@ -6,12 +6,14 @@
             [ring.util.response :as ring-resp]
             [turbovote.resource-config :refer [config]]
             [pedestal-toolbox.params :refer :all]
+            [pedestal-toolbox.cors :as cors]
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
             [clojure.core.async :refer [go alt! timeout]]
             [bifrost.core :as bifrost]
             [bifrost.interceptors :as bifrost.i]
             [election-http-api.channels :as channels]
+            [clojure.tools.logging :as log]
             [clojure.string :as str]))
 
 (def ping
@@ -51,13 +53,14 @@
                        [:body :electorates] [:body] identity)]]]]])
 
 (defn service []
-  {::env :prod
-   ::bootstrap/router :linear-search
-   ::bootstrap/routes routes
-   ::bootstrap/resource-path "/public"
-   ::bootstrap/allowed-origins (if (= :all (config [:server :allowed-origins]))
-                                 (constantly true)
-                                 (config [:server :allowed-origins]))
-   ::bootstrap/host (config [:server :hostname])
-   ::bootstrap/type :immutant
-   ::bootstrap/port (config [:server :port])})
+  (let [allowed-origins (config [:server :allowed-origins])]
+    (log/debug "Allowed Origins Config: " (pr-str allowed-origins))
+    {::env :prod
+     ::bootstrap/router :linear-search
+     ::bootstrap/routes routes
+     ::bootstrap/resource-path "/public"
+     ::bootstrap/allowed-origins (cors/domain-matcher-fn
+                                  (map re-pattern allowed-origins))
+     ::bootstrap/host (config [:server :hostname])
+     ::bootstrap/type :immutant
+     ::bootstrap/port (config [:server :port])}))


### PR DESCRIPTION
This is a breaking change for the way we configure our servers. We want
to allow regexes for matching CORS Origin headers instead of using
String equality.

This PR should be reviewed well because it will be used as a model to
change all http-api services. We will also need to update Krakenstein's
docker-compose.yml to change the default dev ALLOWED_ORIGINS from
`:all`, which no longer will work. Before deploying any of those
services, we should change the Consul keys for allowed-origins for each
of the services to reflect all subdomains of "turbovote.org". The new
value should be `["https://(.+[.])?turbovote[.]org"]`.

This PR is blocked by the review and release of https://github.com/democracyworks/pedestal-toolbox/pull/17. We assume pedestal-toolbox will have the new version of "0.7.0" because it is a non-breaking change but not a bug fix.

[Pivotal Card](https://www.pivotaltracker.com/story/show/112013999)