### PR TITLE
Run without WildFly

### DIFF
--- a/election-http-api@.service.template
+++ b/election-http-api@.service.template
@@ -6,13 +6,12 @@ After=consul@%i.service
 Wants=consul@%i.service
 After=rabbitmq@%i.service
 Requires=rabbitmq@%i.service
-After=wildfly@%i.service
-Requires=wildfly@%i.service
 
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=10m
 TimeoutStopSec=10m
+Restart=on-failure
 
 Environment=DOCKER_REPO=
 Environment=VERSION=
@@ -24,13 +23,15 @@ ExecStartPre=-/usr/bin/docker rm ${CONTAINER}
 ExecStartPre=/bin/bash -c 'sleep 2 && curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/dockercfg?raw -o /root/.dockercfg'
 ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 
-ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} --restart=always \
-  --link rabbitmq:rabbitmq \
-  --link wildfly:wildfly \
+ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env ALLOWED_ORIGINS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/election-http-api/allowed-origins?raw)" \
+  --env RABBITMQ_PORT_5672_TCP_ADDR=rabbitmq.service.consul \
+  --env RABBITMQ_PORT_5672_TCP_PORT=5672 \
+  --env LEIN_ARGS="with-profile production" \
+  --publish 8080 \
   ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}
 
 [X-Fleet]
-MachineOf=wildfly@%i.service
+MachineOf=consul@%i.service


### PR DESCRIPTION
As a part of [this card](https://www.pivotaltracker.com/story/show/134857081) I'm attempting to stand up a new WildFly-free TurboVote cluster.

This was the minimum changes necessary to election-http-api to make that work (along with some changes to synapse-balancer's config in [this PR](https://github.com/democracyworks/synapse-balancer/pull/22)). It is deployed to the new cluster and working via curl.

This PR is targeting a `newprod` branch so that we can tell BuildKite to only deploy that branch to the new cluster (and keep deploying `master` to the Death Star until we're ready to cut over to the new cluster).

Once the overall approach is approved, I'd like to apply it to the other `http-api` components w/o a PR review unless there is something significantly different from this in any of the others. Let me know if you have thoughts on that approach.