### PR TITLE
3scale java lib

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,43 @@
-app:
-  build: .
-  links:
-    - rabbitmq
-    - wildfly
-  environment:
-    ALLOWED_ORIGINS: '[".*"]'
-wildfly:
-  image: quay.io/democracyworks/wildfly:9.0.2.Final-debug
-  links:
-    - rabbitmq
-  ports:
-    - "59990:9990"
-    - "58080:8080"
-  environment:
-    ADMIN_USERNAME: admin
-    ADMIN_PASSWORD: admin
-rabbitmq:
-  image: rabbitmq:3.5.3-management
-  ports:
-    - "45672:5672"
-    - "55672:15672"
-  hostname: rabbitmq
+version: '3'
+services:
+  election-http-api:
+    build: .
+    depends_on:
+      - rabbitmq
+    environment:
+      ALLOWED_ORIGINS: '[".*"]'
+      RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
+      RABBITMQ_PORT_5672_TCP_PORT: 5672
+      3SCALE_PROVIDER_KEY:
+      3SCALE_SERVICE_ID:
+    ports:
+      - "58080:8080"
+  election-works:
+    image: quay.io/democracyworks/election-works:tvprod
+    depends_on:
+      - rabbitmq
+      - datomic
+    environment:
+      ELECTION_WORKS_DATOMIC_URI: "datomic:dev://datomic:4334/election-works"
+      INITIALIZE_DATOMIC: "true"
+      RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
+      RABBITMQ_PORT_5672_TCP_PORT: 5672
+      ELECTION_WORKS_ELECTION_READ_THREADS: 2
+      ELECTION_WORKS_ELECTION_UPCOMING_THREADS: 2
+      ELECTION_WORKS_ELECTION_CREATE_THREADS: 2
+      ELECTION_WORKS_ELECTION_UPDATE_THREADS: 2
+      ELECTION_WORKS_ELECTION_DELETE_THREADS: 2
+      ELECTION_WORKS_ELECTION_SEARCH_THREADS: 2
+  rabbitmq:
+    image: rabbitmq:3.6.5-management
+    ports:
+      - "45672:5672"
+      - "55672:15672"
+    hostname: rabbitmq
+  datomic:
+    image: quay.io/democracyworks/datomic-tx:0.9.5544
+    ports:
+      - "4334:4334"
+      - "4335:4335"
+      - "4336:4336"
+    hostname: datomic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       ALLOWED_ORIGINS: '[".*"]'
       RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
       RABBITMQ_PORT_5672_TCP_PORT: 5672
-      3SCALE_PROVIDER_KEY:
+      3SCALE_SERVICE_TOKEN:
       3SCALE_SERVICE_ID:
     ports:
       - "58080:8080"

--- a/election-http-api@.service.template
+++ b/election-http-api@.service.template
@@ -26,6 +26,8 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --dns $COREOS_PRIVATE_IPV4 \
   --env ALLOWED_ORIGINS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/election-http-api/allowed-origins?raw)" \
   --env NEW_RELIC_LICENSE_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/new-relic/license-key?raw) \
+  --env 3SCALE_SERVICE_TOKEN=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/3scale/service-token?raw) \
+  --env 3SCALE_SERVICE_ID=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/3scale/service-id?raw) \
   --env RABBITMQ_PORT_5672_TCP_ADDR=rabbitmq.service.consul \
   --env RABBITMQ_PORT_5672_TCP_PORT=5672 \
   --env LEIN_ARGS="with-profile production" \

--- a/project.clj
+++ b/project.clj
@@ -5,27 +5,27 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [turbovote.resource-config "0.2.0"]
-                 [com.novemberain/langohr "3.5.1"]
-                 [prismatic/schema "1.1.1"]
-                 [ch.qos.logback/logback-classic "1.1.7"]
+                 [turbovote.resource-config "0.2.1"]
+                 [com.novemberain/langohr "3.7.0"]
+                 [prismatic/schema "1.1.3"]
+                 [ch.qos.logback/logback-classic "1.1.9"]
 
                  ;; core.async has to come before pedestal or kehaar.wire-up will
                  ;; not compile. Something to do with the try-catch in
                  ;; kehaar.core/go-handler. (This may not be true anymore in
                  ;; core.async 0.2.x; need to test.)
-                 [org.clojure/core.async "0.2.374"]
-                 [democracyworks/kehaar "0.8.1"]
+                 [org.clojure/core.async "0.2.395"]
+                 [democracyworks/kehaar "0.9.0"]
 
-                 [io.pedestal/pedestal.service "0.4.1"]
-                 [io.pedestal/pedestal.service-tools "0.4.1"]
+                 [io.pedestal/pedestal.service "0.5.2"]
+                 [io.pedestal/pedestal.service-tools "0.5.2"]
                  [democracyworks/pedestal-toolbox "0.7.0"]
-                 [org.immutant/web "2.1.4"]
-                 [io.pedestal/pedestal.immutant "0.4.1"]
-                 [org.immutant/core "2.1.4"]
+                 [org.immutant/web "2.1.6"]
+                 [io.pedestal/pedestal.immutant "0.5.2"]
+                 [org.immutant/core "2.1.6"]
                  [democracyworks/bifrost "0.1.5"]]
   :plugins [[lein-immutant "2.1.0"]
-            [com.carouselapps/jar-copier "0.3.0"]]
+            [com.carouselapps/jar-copier "0.3.1"]]
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.35.1"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}
@@ -34,5 +34,5 @@
   :uberjar-name "election-http-api.jar"
   :profiles {:uberjar {:aot :all}
              :dev {:resource-paths ["dev-resources"]}
-             :test {:dependencies [[clj-http "3.1.0"]]
+             :test {:dependencies [[clj-http "3.4.1"]]
                     :jvm-opts ["-Dlog-level=OFF"]}})

--- a/project.clj
+++ b/project.clj
@@ -8,18 +8,14 @@
                  [turbovote.resource-config "0.2.1"]
                  [com.novemberain/langohr "3.7.0"]
                  [prismatic/schema "1.1.3"]
-                 [ch.qos.logback/logback-classic "1.1.9"]
+                 [ch.qos.logback/logback-classic "1.1.10"]
 
                  ;; core.async has to come before pedestal or kehaar.wire-up will
                  ;; not compile. Something to do with the try-catch in
                  ;; kehaar.core/go-handler. (This may not be true anymore in
                  ;; core.async 0.2.x; need to test.)
                  [org.clojure/core.async "0.2.395"]
-                 <<<<<<< HEAD
                  [democracyworks/kehaar "0.9.0"]
-                 =======
-                 [democracyworks/kehaar "0.8.1"]
-                 >>>>>>> Update deps
 
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.service-tools "0.5.2"]
@@ -30,7 +26,7 @@
                  [democracyworks/bifrost "0.1.5"]
                  [~(symbol "net.3scale" "3scale-api") "3.0.2"]] ; ewww, but symbols can't start w/ a 3
   :plugins [[lein-immutant "2.1.0"]
-            [com.carouselapps/jar-copier "0.3.1"]]
+            [com.pupeno/jar-copier "0.4.0"]]
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.35.1"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,11 @@
                  ;; kehaar.core/go-handler. (This may not be true anymore in
                  ;; core.async 0.2.x; need to test.)
                  [org.clojure/core.async "0.2.395"]
+                 <<<<<<< HEAD
                  [democracyworks/kehaar "0.9.0"]
+                 =======
+                 [democracyworks/kehaar "0.8.1"]
+                 >>>>>>> Update deps
 
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.service-tools "0.5.2"]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,8 @@
                  [org.immutant/web "2.1.6"]
                  [io.pedestal/pedestal.immutant "0.5.2"]
                  [org.immutant/core "2.1.6"]
-                 [democracyworks/bifrost "0.1.5"]]
+                 [democracyworks/bifrost "0.1.5"]
+                 [~(symbol "net.3scale" "3scale-api") "3.0.2"]] ; ewww, but symbols can't start w/ a 3
   :plugins [[lein-immutant "2.1.0"]
             [com.carouselapps/jar-copier "0.3.1"]]
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.35.1"]]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [io.pedestal/pedestal.immutant "0.5.2"]
                  [org.immutant/core "2.1.6"]
                  [democracyworks/bifrost "0.1.5"]
-                 [~(symbol "net.3scale" "3scale-api") "3.0.2"]] ; ewww, but symbols can't start w/ a 3
+                 [~(symbol "net.3scale" "3scale-api") "3.0.3"]] ; ewww, but symbols can't start w/ a 3
   :plugins [[lein-immutant "2.1.0"]
             [com.pupeno/jar-copier "0.4.0"]]
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.35.1"]]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,8 +14,8 @@
                      [{:queue "election-works.election.search"
                        :channel election-http-api.channels/election-upcoming-search
                        :response true
-                       :timeout 10000}
+                       :timeout 60000}
                       {:queue "electorate-works.electorate.search-create"
                        :channel election-http-api.channels/electorate-search-create
                        :response true
-                       :timeout 10000}]}}}
+                       :timeout 60000}]}}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -15,6 +15,10 @@
                        :channel election-http-api.channels/election-upcoming-search
                        :response true
                        :timeout 60000}
+                      {:queue "election-works.election.upcoming"
+                       :channel election-http-api.channels/election-all-upcoming
+                       :response true
+                       :timeout 60000}
                       {:queue "electorate-works.electorate.search-create"
                        :channel election-http-api.channels/electorate-search-create
                        :response true

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -22,4 +22,6 @@
                       {:queue "electorate-works.electorate.search-create"
                        :channel election-http-api.channels/electorate-search-create
                        :response true
-                       :timeout 60000}]}}}
+                       :timeout 60000}]}}
+ :3scale {:provider-key #resource-config/env "3SCALE_PROVIDER_KEY"
+          :service-id #resource-config/env "3SCALE_SERVICE_ID"}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -23,5 +23,5 @@
                        :channel election-http-api.channels/electorate-search-create
                        :response true
                        :timeout 60000}]}}
- :3scale {:provider-key #resource-config/env "3SCALE_PROVIDER_KEY"
+ :3scale {:service-token #resource-config/env "3SCALE_SERVICE_TOKEN"
           :service-id #resource-config/env "3SCALE_SERVICE_ID"}}

--- a/src/election_http_api/channels.clj
+++ b/src/election_http_api/channels.clj
@@ -2,10 +2,11 @@
   (:require [clojure.core.async :as async]))
 
 (defonce election-upcoming-search (async/chan 1000))
-
+(defonce election-all-upcoming (async/chan 1000))
 (defonce electorate-search-create (async/chan 1000))
 
 (defn close-all! []
   (doseq [c [election-upcoming-search
+             election-all-upcoming
              electorate-search-create]]
     (async/close! c)))

--- a/src/election_http_api/service.clj
+++ b/src/election_http_api/service.clj
@@ -15,8 +15,7 @@
             [election-http-api.channels :as channels]
             [clojure.tools.logging :as log]
             [clojure.string :as str]
-            [election-http-api.three-scale :as ts])
-  (:import (threescale.v3.api ServerError)))
+            [election-http-api.three-scale :as ts]))
 
 (def ping
   (interceptor

--- a/src/election_http_api/service.clj
+++ b/src/election_http_api/service.clj
@@ -50,6 +50,7 @@
     (fn [{:keys [request] :as ctx}]
       (if (get-in request [:query-params :user-key])
         (let [authorization (ts/authorize-request request)]
+          (log/debug "3scale API authorization response:" (pr-str authorization))
           (case (::ts/status authorization)
             ::ts/authorized ctx
             ::ts/not-authorized (assoc-response

--- a/src/election_http_api/three_scale.clj
+++ b/src/election_http_api/three_scale.clj
@@ -1,5 +1,6 @@
 (ns election-http-api.three-scale
-  (:require [turbovote.resource-config :refer [config]])
+  (:require [turbovote.resource-config :refer [config]]
+            [clojure.tools.logging :as log])
   (:import (threescale.v3.api ParameterMap AuthorizeResponse ServerError)
            (threescale.v3.api.impl ServiceApiDriver)))
 
@@ -10,6 +11,7 @@
   (.getReason three-scale-response))
 
 (defn authorize-request [{{:keys [user-key]} :query-params}]
+  (log/debug "Authorizing API request for user-key" user-key)
   (let [provider-key (config [:3scale :provider-key])
         service-id (config [:3scale :service-id])
         service-api (ServiceApiDriver. provider-key)

--- a/src/election_http_api/three_scale.clj
+++ b/src/election_http_api/three_scale.clj
@@ -1,0 +1,32 @@
+(ns election-http-api.three-scale
+  (:require [turbovote.resource-config :refer [config]])
+  (:import (threescale.v3.api ParameterMap AuthorizeResponse ServerError)
+           (threescale.v3.api.impl ServiceApiDriver)))
+
+(defn authorized? [^AuthorizeResponse three-scale-response]
+  (.success three-scale-response))
+
+(defn failure-reason [^AuthorizeResponse three-scale-response]
+  (.getReason three-scale-response))
+
+(defn authorize-request [{{:keys [user-key]} :query-params}]
+  (let [provider-key (config [:3scale :provider-key])
+        service-id (config [:3scale :service-id])
+        service-api (ServiceApiDriver. provider-key)
+        usage (doto (ParameterMap.)
+                (.add "hits" "1"))
+        params (doto (ParameterMap.)
+                 (.add "user_key" ^String user-key)
+                 (.add "service_id" ^String service-id)
+                 (.add "usage" usage))]
+    (try
+      (let [response (.authrep service-api params)]
+        (if (authorized? response)
+          {::status ::authorized
+           ::auth-response response}
+          {::status ::not-authorized
+           ::message (failure-reason response)
+           ::auth-response response}))
+      (catch ServerError error
+        {::status ::error
+         ::message (.getMessage error)}))))

--- a/src/election_http_api/three_scale.clj
+++ b/src/election_http_api/three_scale.clj
@@ -12,17 +12,16 @@
 
 (defn authorize-request [{{:keys [user-key]} :query-params}]
   (log/debug "Authorizing API request for user-key" user-key)
-  (let [provider-key (config [:3scale :provider-key])
+  (let [service-token (config [:3scale :service-token])
         service-id (config [:3scale :service-id])
-        service-api (ServiceApiDriver. provider-key)
+        service-api (ServiceApiDriver/createApi)
         usage (doto (ParameterMap.)
                 (.add "hits" "1"))
         params (doto (ParameterMap.)
                  (.add "user_key" ^String user-key)
-                 (.add "service_id" ^String service-id)
                  (.add "usage" usage))]
     (try
-      (let [response (.authrep service-api params)]
+      (let [response (.authrep service-api service-token service-id params)]
         (if (authorized? response)
           {::status ::authorized
            ::auth-response response}

--- a/src/election_http_api/three_scale.clj
+++ b/src/election_http_api/three_scale.clj
@@ -4,6 +4,8 @@
   (:import (threescale.v3.api ParameterMap AuthorizeResponse ServerError)
            (threescale.v3.api.impl ServiceApiDriver)))
 
+(def api-client (ServiceApiDriver/createApi))
+
 (defn authorized? [^AuthorizeResponse three-scale-response]
   (.success three-scale-response))
 
@@ -14,14 +16,13 @@
   (log/debug "Authorizing API request for user-key" user-key)
   (let [service-token (config [:3scale :service-token])
         service-id (config [:3scale :service-id])
-        service-api (ServiceApiDriver/createApi)
         usage (doto (ParameterMap.)
                 (.add "hits" "1"))
         params (doto (ParameterMap.)
                  (.add "user_key" ^String user-key)
                  (.add "usage" usage))]
     (try
-      (let [response (.authrep service-api service-token service-id params)]
+      (let [response (.authrep api-client service-token service-id params)]
         (if (authorized? response)
           {::status ::authorized
            ::auth-response response}

--- a/test/election_http_api/service_test.clj
+++ b/test/election_http_api/service_test.clj
@@ -9,8 +9,7 @@
             [clojure.test :refer :all]
             [clojure.string :as str]
             [clj-time.core :as t]
-            [clj-time.coerce :as tc])
-  (:import (threescale.v3.api ServerError)))
+            [clj-time.coerce :as tc]))
 
 (def test-server-port 56000) ; FIXME: Pick a port unique to this project
 

--- a/test/election_http_api/service_test.clj
+++ b/test/election_http_api/service_test.clj
@@ -1,6 +1,7 @@
 (ns election-http-api.service-test
   (:require [election-http-api.server :as server]
             [election-http-api.channels :as channels]
+            [election-http-api.three-scale :as ts]
             [clj-http.client :as http]
             [clojure.edn :as edn]
             [cognitect.transit :as transit]
@@ -8,7 +9,8 @@
             [clojure.test :refer :all]
             [clojure.string :as str]
             [clj-time.core :as t]
-            [clj-time.coerce :as tc]))
+            [clj-time.coerce :as tc])
+  (:import (threescale.v3.api ServerError)))
 
 (def test-server-port 56000) ; FIXME: Pick a port unique to this project
 
@@ -50,6 +52,10 @@
     denver-ocd-id (async/put! response-ch {:status :ok
                                            :elections #{denver-election}})
     (async/put! response-ch {:status :ok, :elections #{}})))
+
+(defn test-election-works-all-upcoming-response
+  [[response-ch _]]
+  (async/put! response-ch {:status :ok, :elections #{denver-election}}))
 
 (def test-user-1
   {:id #uuid "a9acf0fb-5e74-4afb-822a-0078aec27e37"})
@@ -101,7 +107,49 @@
                 :election-authority {}
                 :voter-registration-authority {}}}
              (edn/read-string (:body response))))))
-  (testing "/upcoming with no query params returns 404"
+  (testing "/upcoming with no query params returns 403"
     (let [response (http/get (str root-url "/upcoming")
                              {:throw-exceptions false})]
-      (is (= 404 (:status response))))))
+      (is (= 403 (:status response)))))
+  (testing "/upcoming with valid user-key returns all upcoming elections"
+    (async/take! channels/election-all-upcoming
+                 test-election-works-all-upcoming-response)
+    (with-redefs [ts/authorize-request
+                  (fn [req]
+                    (when (= (get-in req [:query-params :user-key])
+                             "totally-valid")
+                      {::ts/status ::ts/authorized}))]
+      (let [response (http/get (str root-url "/upcoming")
+                               {:query-params
+                                {:user-key "totally-valid"}})]
+        (is (= 200 (:status response)))
+        (is (= #{denver-election}
+               (edn/read-string (:body response)))))))
+  (testing "/upcoming with not-authorized response from 3scale returns 403"
+    (with-redefs [ts/authorize-request (constantly
+                                        {::ts/status ::ts/not-authorized
+                                         ::ts/message "expected failure"})]
+      (let [response (http/get (str root-url "/upcoming")
+                               {:query-params
+                                {:user-key "totally-valid"}
+                                :throw-exceptions false})]
+        (is (= 403 (:status response)))
+        (is (= "expected failure"
+               (-> response
+                   :body
+                   edn/read-string
+                   :message))))))
+  (testing "/upcoming with auth error responds with 500"
+    (with-redefs [ts/authorize-request (constantly
+                                        {::ts/status ::ts/error
+                                         ::ts/message "expected error"})]
+      (let [response (http/get (str root-url "/upcoming")
+                               {:query-params
+                                {:user-key "totally-valid"}
+                                :throw-exceptions false})]
+        (is (= 500 (:status response)))
+        (is (= "expected error"
+               (-> response
+                   :body
+                   edn/read-string
+                   :message)))))))


### PR DESCRIPTION
This uses the 3scale java library to authenticate & authorize API requests instead of using them as a gateway. This will allow us to put this API up on any hostname we want, hosted the same way we host our existing public APIs (and to more easily integrate 3scale services into those existing APIs in the future).

I tested this in its local docker-compose stack and it worked. Valid user-key let me hit the `/upcoming` endpoint (and it returned the elections that `election-works` had in its database), invalid user-key gave me a 403 error. Existing endpoints unaffected.

[Pivotal card](https://www.pivotaltracker.com/story/show/138438233)