### PR TITLE
Move api key into Authorization header

### DIFF
--- a/src/election_http_api/service.clj
+++ b/src/election_http_api/service.clj
@@ -47,20 +47,16 @@
   (interceptor
    {:enter
     (fn [{:keys [request] :as ctx}]
-      (if (get-in request [:query-params :user-key])
-        (let [authorization (ts/authorize-request request)]
-          (log/debug "3scale API authorization response:" (pr-str authorization))
-          (case (::ts/status authorization)
-            ::ts/authorized ctx
-            ::ts/not-authorized (assoc-response
-                                 ctx
-                                 403
-                                 {:message
-                                  (::ts/message authorization)})
-            ::ts/error (assoc-response ctx 500 {:message
-                                                (::ts/message authorization)})
-            (assoc-response ctx 500 {:message "Unknown auth error"})))
-        (assoc-response ctx 403 {:message "user-key query param missing"})))}))
+      (let [authorization (ts/authorize-request request)]
+        (log/debug "3scale API authorization response:" (pr-str authorization))
+        (case (::ts/status authorization)
+          ::ts/authorized ctx
+          ::ts/not-authorized (assoc-response ctx 403
+                                              {:message
+                                               (::ts/message authorization)})
+          ::ts/error (assoc-response ctx 500
+                                     {:message (::ts/message authorization)})
+          (assoc-response ctx 500 {:message "Unknown auth error"}))))}))
 
 (defroutes routes
   [[["/"


### PR DESCRIPTION
Should be more secure than having it in the query string. Headers
should look this (assuming api key is 'foobar'):

`Authorization: apikey foobar`